### PR TITLE
Added null check after GetCustomSongInfo and ignore null songs.

### DIFF
--- a/BeatSaverDownloader/CustomViewController.cs
+++ b/BeatSaverDownloader/CustomViewController.cs
@@ -462,7 +462,9 @@ namespace BeatSaverDownloader
                 foreach (var result in results)
                 {
                     var songPath = Path.GetDirectoryName(result).Replace('\\', '/');
-                    customSongInfos.Add(GetCustomSongInfo(songPath));
+                    var customSong = GetCustomSongInfo(songPath);
+                    if (customSong == null) continue;
+                    customSongInfos.Add(customSong);
                 }
             }
 


### PR DESCRIPTION
If there's an invalid custom song, BeatSaverDownloader will be unable to open its menu when you press the button. Adding a simple null check fixes this problem.